### PR TITLE
Fixed protocol link for fiber triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The FIP (Frame-projected Independent Photometry) system is a low-cost, scalable 
 For more information, see the [AIND Fiber Photometry Platform Page](https://www.allenneuraldynamics.org/platforms/fiber-photometry) and the following protocols:  
 
 * Protocol for system assembly: <https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2>
-* Protocol for system triggering setup: <https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2>
+* Protocol for system triggering setup: <https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-kxygx3e6wg8j/v1>
 
 ## Wavelength Information
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The FIP (Frame-projected Independent Photometry) system is a low-cost, scalable 
 
 For more information, see the [AIND Fiber Photometry Platform Page](https://www.allenneuraldynamics.org/platforms/fiber-photometry) and the following protocols:  
 
-* Protocol for system assembly: <https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2>
-* Protocol for system triggering setup: <https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-kxygx3e6wg8j/v1>
+* [Protocol for system assembly](https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2)
+* [Protocol for system triggering setup](https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-kxygx3e6wg8j/v1)
 
 ## Wavelength Information
 


### PR DESCRIPTION
Fixes protocol link for "Protocol for system triggering setup:" in readme. Changes from "https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2" (which is actually the link for "Protocol for system assembly" and is mistakenly repeated from above) to "https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-kxygx3e6wg8j/v1"

Closes #38 