### PR TITLE
Remove timing/triggering protocol from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The FIP (Frame-projected Independent Photometry) system is a low-cost, scalable 
 
 For more information, see the [AIND Fiber Photometry Platform Page](https://www.allenneuraldynamics.org/platforms/fiber-photometry) and the following protocols:  
 
-* Protocol for system assembly: <https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2>
-* Protocol for system triggering setup: <https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2>
+* [Protocol for system assembly](https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2)
+* Protocol for system triggering setup: No current protocol exists. An outdated protocol is [here](https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-kxygx3e6wg8j/v1). See [this issue](https://github.com/AllenNeuralDynamics/Aind.Physiology.Fip/issues/42).
 
 ## Wavelength Information
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The FIP (Frame-projected Independent Photometry) system is a low-cost, scalable 
 For more information, see the [AIND Fiber Photometry Platform Page](https://www.allenneuraldynamics.org/platforms/fiber-photometry) and the following protocols:  
 
 * [Protocol for system assembly](https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-261ge39edl47/v2)
-* Protocol for system triggering setup: No current protocol exists. An outdated protocol is [here](https://www.protocols.io/view/modified-frame-projected-independent-fiber-photome-kxygx3e6wg8j/v1). See [this issue](https://github.com/AllenNeuralDynamics/Aind.Physiology.Fip/issues/42).
 
 ## Wavelength Information
 


### PR DESCRIPTION
~An interim fix to the readme related to #38. A proper fix is in #39. However, that PR is blocked by #42. This PR simply removes the duplicated link identified in #38 to avoid confusion while we await resolution of #42.~
EDIT: Given comment https://github.com/AllenNeuralDynamics/Aind.Physiology.Fip/pull/43#issuecomment-3609502488 and https://github.com/AllenNeuralDynamics/Aind.Physiology.Fip/pull/43#issuecomment-3609601599, I'm simply removing the reference to the timing protocol in this PR.

Closes #38 